### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "local-model-provider",
   "displayName": "Local Model Provider",
-  "description": "VS Code extension to connect to local LLM inference servers (Ollama, llama.cpp, LocalAI, LM Studio, vLLM) via OpenAI API compatible endpoints.",
+  "description": "VS Code extension to connect to local or cloud LLM inference servers (Ollama, llama.cpp, LocalAI, LM Studio, vLLM, Astraflow) via OpenAI API compatible endpoints.",
   "version": "1.1.2",
   "publisher": "krevas",
   "icon": "assets/local-model-provider.png",
@@ -44,7 +44,9 @@
     "function calling",
     "tool calling",
     "model provider",
-    "gateway"
+    "gateway",
+    "astraflow",
+    "ucloud"
   ],
   "activationEvents": [
     "onStartupFinished"
@@ -95,12 +97,21 @@
         "local.model.provider.serverUrl": {
           "type": "string",
           "default": "http://localhost:8000",
-          "description": "Inference server URL (OpenAI API compatible endpoint)",
+          "description": "Inference server URL (OpenAI API compatible endpoint). Supports local servers (Ollama, llama.cpp, LM Studio, vLLM) and cloud providers such as Astraflow (https://astraflow.ucloud-global.com).",
           "order": 1
         },
         "local.model.provider.serverPresets": {
           "type": "array",
-          "default": [],
+          "default": [
+            {
+              "name": "Astraflow (Global)",
+              "url": "https://api-us-ca.umodelverse.ai/v1"
+            },
+            {
+              "name": "Astraflow (China)",
+              "url": "https://api.modelverse.cn/v1"
+            }
+          ],
           "items": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Summary

Adds [Astraflow by UCloud](https://astraflow.ucloud-global.com) as a supported cloud inference provider for the Local Model Provider extension.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models, so no new SDK or code changes are required — only configuration.

## Changes

### `package.json`
- **Description**: Updated to mention Astraflow alongside the existing local server list, making it clear the extension also works with cloud OpenAI-compatible endpoints.
- **Keywords**: Added `"astraflow"` and `"ucloud"` so users searching the VS Code Marketplace can discover this extension when looking for Astraflow support.
- **`serverUrl` description**: Clarified that the URL field supports cloud providers and linked to Astraflow's website as an example.
- **`serverPresets` default**: Added two built-in presets for Astraflow out of the box:
  - **Astraflow (Global)** → `https://api-us-ca.umodelverse.ai/v1` (uses `ASTRAFLOW_API_KEY`)
  - **Astraflow (China)** → `https://api.modelverse.cn/v1` (uses `ASTRAFLOW_CN_API_KEY`)

  Users can immediately switch to either endpoint via the **"Switch Server Preset"** command without manually typing the URL.

## How to use Astraflow

1. Sign up at https://astraflow.ucloud-global.com (global) or https://astraflow.ucloud.cn (China) to obtain an API key.
2. In VS Code, run **Local Model Provider: Set API Key (Secure)** and paste your Astraflow API key.
3. Run **Local Model Provider: Switch Server Preset** and select **Astraflow (Global)** or **Astraflow (China)**.
4. The extension will automatically fetch the 200+ available models from Astraflow's endpoint.

## Why minimum changes?

Because Astraflow is fully OpenAI-compatible, no new SDK, no new subpackage, and no new source files are needed. The entire integration is a URL + API key, which exactly matches what `serverUrl` / `setApiKey` already support.